### PR TITLE
Minor revisions

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -6,7 +6,7 @@
     "version": 1,
 
     // The name of the project being benchmarked
-    "project": "PennyLane",
+    "project": "pennylane",
 
     // The project's homepage
     "project_url": "pennylane.ai",

--- a/benchmarks/asv/app_suite.py
+++ b/benchmarks/asv/app_suite.py
@@ -26,7 +26,7 @@ from ..benchmark_functions.qaoa import benchmark_qaoa
 import networkx as nx
 
 
-class VQE_light:
+class VQE_small:
     """Benchmark the VQE algorithm using different number of optimization steps and grouping
      options."""
 
@@ -98,7 +98,7 @@ class VQE_heavy:
         benchmark_vqe(hyperparams)
 
 
-class QAOA_light:
+class QAOA_small:
     """Benchmark the QAOA algorithm for finding the minimum vertex cover of a small graph using
     different number of layers."""
 

--- a/benchmarks/asv/app_suite.py
+++ b/benchmarks/asv/app_suite.py
@@ -26,7 +26,7 @@ from ..benchmark_functions.qaoa import benchmark_qaoa
 import networkx as nx
 
 
-class VQE_small:
+class VQE_light:
     """Benchmark the VQE algorithm using different number of optimization steps and grouping
      options."""
 
@@ -98,7 +98,7 @@ class VQE_heavy:
         benchmark_vqe(hyperparams)
 
 
-class QAOA_small:
+class QAOA_light:
     """Benchmark the QAOA algorithm for finding the minimum vertex cover of a small graph using
     different number of layers."""
 

--- a/benchmarks/asv/core_suite.py
+++ b/benchmarks/asv/core_suite.py
@@ -19,7 +19,7 @@ from ..benchmark_functions.gradient import benchmark_gradient
 from ..benchmark_functions.optimization import benchmark_optimization
 
 
-class CircuitEvaluation:
+class CircuitEvaluation_small:
     """Benchmark the evaluation of a circuit using different widths and depths."""
 
     params = ([2, 5, 10], [3, 6, 9])
@@ -32,45 +32,26 @@ class CircuitEvaluation:
         benchmark_circuit(hyperparams)
 
 
-class GradientComputation:
+class GradientComputation_small:
     """Time the computation of a gradient using different widths and depths."""
 
-    params = ([2, 5], [3, 6])
-    param_names = ['n_wires', 'n_layers']
+    params = ([2, 5], [3, 6], ['autograd', 'tf', 'torch'])
+    param_names = ['n_wires', 'n_layers','interface']
 
-    def time_gradient_autograd(self, n_wires, n_layers):
+    def time_gradient(self, n_wires, n_layers, interface):
         hyperparams = {'n_wires': n_wires,
                        'n_layers': n_layers,
-                       'interface': 'autograd'}
-        benchmark_gradient(hyperparams)
-
-    def time_gradient_tf(self, n_wires, n_layers):
-        hyperparams = {'n_wires': n_wires,
-                       'n_layers': n_layers,
-                       'interface': 'tf'}
-        benchmark_gradient(hyperparams)
-
-    def time_gradient_torch(self, n_wires, n_layers):
-        hyperparams = {'n_wires': n_wires,
-                       'n_layers': n_layers,
-                       'interface': 'torch'}
+                       'interface': interface}
         benchmark_gradient(hyperparams)
 
 
-class Optimization:
+class Optimization_small:
     """Benchmark the optimization of a circuit."""
 
-    def time_optimization_autograd(self):
-        """Time gradient descent on the default circuit using autograd."""
-        hyperparams = {'interface': 'autograd'}
-        benchmark_optimization(hyperparams, n_steps=10)
+    params = (['autograd','tf','torch'])
+    param_names = ['interface']
 
-    def time_optimization_tf(self):
-        """Time gradient descent on the default circuit using tf."""
-        hyperparams = {'interface': 'tf'}
-        benchmark_optimization(hyperparams, n_steps=10)
-
-    def time_optimization_torch(self):
-        """Time gradient descent on the default circuit using torch."""
-        hyperparams = {'interface': 'torch'}
+    def time_optimization(self, interface):
+        """Time gradient descent on the default circuit using an interface."""
+        hyperparams = {'interface': interface}
         benchmark_optimization(hyperparams, n_steps=10)

--- a/benchmarks/asv/core_suite.py
+++ b/benchmarks/asv/core_suite.py
@@ -19,7 +19,7 @@ from ..benchmark_functions.gradient import benchmark_gradient
 from ..benchmark_functions.optimization import benchmark_optimization
 
 
-class CircuitEvaluation_small:
+class CircuitEvaluation_light:
     """Benchmark the evaluation of a circuit using different widths and depths."""
 
     params = ([2, 5, 10], [3, 6, 9])
@@ -32,7 +32,7 @@ class CircuitEvaluation_small:
         benchmark_circuit(hyperparams)
 
 
-class GradientComputation_small:
+class GradientComputation_light:
     """Time the computation of a gradient using different widths and depths."""
 
     params = ([2, 5], [3, 6], ['autograd', 'tf', 'torch'])
@@ -45,7 +45,7 @@ class GradientComputation_small:
         benchmark_gradient(hyperparams)
 
 
-class Optimization_small:
+class Optimization_light:
     """Benchmark the optimization of a circuit."""
 
     params = (['autograd','tf','torch'])

--- a/benchmarks/benchmark_functions/circuit.py
+++ b/benchmarks/benchmark_functions/circuit.py
@@ -20,8 +20,6 @@ import torch
 from pennylane import numpy as pnp
 from .default_settings import _core_defaults
 
-qml.enable_tape()
-
 
 def benchmark_circuit(hyperparams={}, num_repeats=1):
 	"""

--- a/benchmarks/benchmark_functions/default_settings.py
+++ b/benchmarks/benchmark_functions/default_settings.py
@@ -78,7 +78,7 @@ def _vqe_defaults(hyperparams):
 	ansatz = partial(UCCSD, init_state=hf_state, s_wires=s_wires, d_wires=d_wires)
 	params = np.array([3.14545258, 3.13766988, -0.21446816])
 
-	ham = hyperparams.pop('Hamiltonian', ham_H)
+	ham = hyperparams.pop('Hamiltonian', ham_h2)
 	ansatz = hyperparams.pop('ansatz', ansatz)
 	params = hyperparams.pop('params', params)
 	n_steps = hyperparams.pop('n_steps', 1)

--- a/benchmarks/benchmark_functions/default_settings.py
+++ b/benchmarks/benchmark_functions/default_settings.py
@@ -14,18 +14,21 @@
 """
 Benchmarks for a machine learning application.
 """
-import pennylane as qml
-from numpy.random import random
-from pennylane.templates import BasicEntanglerLayers
-from pennylane.templates.decorator import template as template_decorator
+import networkx as nx
 
+import pennylane as qml
 from pennylane import numpy as np
-from pennylane.templates.subroutines import UCCSD
-from functools import partial
-from pennylane import Identity, PauliX, PauliY, PauliZ
 from pennylane import qchem
 
-import networkx as nx
+from numpy.random import random
+from functools import partial
+from pennylane.templates import BasicEntanglerLayers
+from pennylane.templates.decorator import template as template_decorator
+from pennylane.templates.subroutines import UCCSD
+from pennylane import Identity, PauliX, PauliY, PauliZ
+
+from .hamiltonians import ham_H
+
 
 def _core_defaults(hyperparams):
 	"""Uses hyperparameters or defaults to construct the components of the circuit.
@@ -65,19 +68,6 @@ def _vqe_defaults(hyperparams):
 	Args:
 		hyperparams (dict): hyperparameters provided by user
 	"""
-	H_coeffs = np.array([-0.05963862, 0.17575739, 0.17575739, -0.23666489, -0.23666489,
-						  0.17001485, 0.04491735, -0.04491735, -0.04491735, 0.04491735,
-						  0.12222641, 0.16714376, 0.16714376, 0.12222641, 0.17570278])
-
-	H_ops = [Identity(wires=[0]), PauliZ(wires=[0]), PauliZ(wires=[1]), PauliZ(wires=[2]),
-			 PauliZ(wires=[3]), PauliZ(wires=[0]) @ PauliZ(wires=[1]),
-			 PauliY(wires=[0]) @ PauliX(wires=[1]) @ PauliX(wires=[2]) @ PauliY(wires=[3]),
-			 PauliY(wires=[0]) @ PauliY(wires=[1]) @ PauliX(wires=[2]) @ PauliX(wires=[3]),
-			 PauliX(wires=[0]) @ PauliX(wires=[1]) @ PauliY(wires=[2]) @ PauliY(wires=[3]),
-			 PauliX(wires=[0]) @ PauliY(wires=[1]) @ PauliY(wires=[2]) @ PauliX(wires=[3]),
-			 PauliZ(wires=[0]) @ PauliZ(wires=[2]), PauliZ(wires=[0]) @ PauliZ(wires=[3]),
-			 PauliZ(wires=[1]) @ PauliZ(wires=[2]), PauliZ(wires=[1]) @ PauliZ(wires=[3]),
-			 PauliZ(wires=[2]) @ PauliZ(wires=[3])]
 
 	electrons = 2
 	qubits = 4
@@ -87,9 +77,8 @@ def _vqe_defaults(hyperparams):
 	hf_state = qchem.hf_state(electrons, qubits)
 	ansatz = partial(UCCSD, init_state=hf_state, s_wires=s_wires, d_wires=d_wires)
 	params = np.array([3.14545258, 3.13766988, -0.21446816])
-	ham = qml.Hamiltonian(H_coeffs, H_ops)
 
-	ham = hyperparams.pop('Hamiltonian', ham)
+	ham = hyperparams.pop('Hamiltonian', ham_H)
 	ansatz = hyperparams.pop('ansatz', ansatz)
 	params = hyperparams.pop('params', params)
 	n_steps = hyperparams.pop('n_steps', 1)

--- a/benchmarks/benchmark_functions/default_settings.py
+++ b/benchmarks/benchmark_functions/default_settings.py
@@ -27,7 +27,7 @@ from pennylane.templates.decorator import template as template_decorator
 from pennylane.templates.subroutines import UCCSD
 from pennylane import Identity, PauliX, PauliY, PauliZ
 
-from .hamiltonians import ham_H
+from .hamiltonians import ham_h2
 
 
 def _core_defaults(hyperparams):

--- a/benchmarks/benchmark_functions/gradient.py
+++ b/benchmarks/benchmark_functions/gradient.py
@@ -20,9 +20,6 @@ import torch
 from pennylane import numpy as pnp
 from .default_settings import _core_defaults
 
-qml.enable_tape()
-
-
 def benchmark_gradient(hyperparams={}, num_repeats=1):
 	"""Computes the gradient of a quantum circuit.
 

--- a/benchmarks/benchmark_functions/hamiltonians.py
+++ b/benchmarks/benchmark_functions/hamiltonians.py
@@ -18,11 +18,11 @@ from pennylane import Identity, PauliX, PauliY, PauliZ
 
 ############ H molecule #################################################
 
-H_coeffs = np.array([-0.05963862, 0.17575739, 0.17575739, -0.23666489, -0.23666489,
+h2_coeffs = np.array([-0.05963862, 0.17575739, 0.17575739, -0.23666489, -0.23666489,
                         0.17001485, 0.04491735, -0.04491735, -0.04491735, 0.04491735,
                         0.12222641, 0.16714376, 0.16714376, 0.12222641, 0.17570278])
 
-H_ops = [Identity(wires=[0]), PauliZ(wires=[0]), PauliZ(wires=[1]), PauliZ(wires=[2]),
+h2_ops = [Identity(wires=[0]), PauliZ(wires=[0]), PauliZ(wires=[1]), PauliZ(wires=[2]),
             PauliZ(wires=[3]), PauliZ(wires=[0]) @ PauliZ(wires=[1]),
             PauliY(wires=[0]) @ PauliX(wires=[1]) @ PauliX(wires=[2]) @ PauliY(wires=[3]),
             PauliY(wires=[0]) @ PauliY(wires=[1]) @ PauliX(wires=[2]) @ PauliX(wires=[3]),
@@ -32,7 +32,7 @@ H_ops = [Identity(wires=[0]), PauliZ(wires=[0]), PauliZ(wires=[1]), PauliZ(wires
             PauliZ(wires=[1]) @ PauliZ(wires=[2]), PauliZ(wires=[1]) @ PauliZ(wires=[3]),
             PauliZ(wires=[2]) @ PauliZ(wires=[3])]
 
-ham_H = qml.Hamiltonian(H_coeffs, H_ops)
+ham_h2 = qml.Hamiltonian(h2_coeffs, h2_ops)
 
 ############# LiH #############################################################
 

--- a/benchmarks/benchmark_functions/hamiltonians.py
+++ b/benchmarks/benchmark_functions/hamiltonians.py
@@ -16,6 +16,26 @@ import pennylane as qml
 from pennylane import numpy as np
 from pennylane import Identity, PauliX, PauliY, PauliZ
 
+############ H molecule #################################################
+
+H_coeffs = np.array([-0.05963862, 0.17575739, 0.17575739, -0.23666489, -0.23666489,
+                        0.17001485, 0.04491735, -0.04491735, -0.04491735, 0.04491735,
+                        0.12222641, 0.16714376, 0.16714376, 0.12222641, 0.17570278])
+
+H_ops = [Identity(wires=[0]), PauliZ(wires=[0]), PauliZ(wires=[1]), PauliZ(wires=[2]),
+            PauliZ(wires=[3]), PauliZ(wires=[0]) @ PauliZ(wires=[1]),
+            PauliY(wires=[0]) @ PauliX(wires=[1]) @ PauliX(wires=[2]) @ PauliY(wires=[3]),
+            PauliY(wires=[0]) @ PauliY(wires=[1]) @ PauliX(wires=[2]) @ PauliX(wires=[3]),
+            PauliX(wires=[0]) @ PauliX(wires=[1]) @ PauliY(wires=[2]) @ PauliY(wires=[3]),
+            PauliX(wires=[0]) @ PauliY(wires=[1]) @ PauliY(wires=[2]) @ PauliX(wires=[3]),
+            PauliZ(wires=[0]) @ PauliZ(wires=[2]), PauliZ(wires=[0]) @ PauliZ(wires=[3]),
+            PauliZ(wires=[1]) @ PauliZ(wires=[2]), PauliZ(wires=[1]) @ PauliZ(wires=[3]),
+            PauliZ(wires=[2]) @ PauliZ(wires=[3])]
+
+ham_H = qml.Hamiltonian(H_coeffs, H_ops)
+
+############# LiH #############################################################
+
 lih_coeffs = np.array([-6.74845266e+00, -1.02553930e-01, 1.00530907e-02, 1.00530907e-02,
                      -1.02553930e-01, 1.00530907e-02, 1.00530907e-02, -2.76355319e-01,
                      -2.76355319e-01, -2.96925596e-01, -2.96925596e-01, -2.96925596e-01,

--- a/benchmarks/benchmark_functions/machine_learning.py
+++ b/benchmarks/benchmark_functions/machine_learning.py
@@ -22,10 +22,6 @@ import torch
 from pennylane import numpy as pnp
 from .default_settings import _core_defaults
 
-
-qml.enable_tape()
-
-
 def _machine_learning_autograd(circuit, params):
 	return NotImplemented
 

--- a/benchmarks/benchmark_functions/optimization.py
+++ b/benchmarks/benchmark_functions/optimization.py
@@ -23,9 +23,6 @@ from pennylane import numpy as pnp
 from .default_settings import _core_defaults
 
 
-qml.enable_tape()
-
-
 def benchmark_optimization(hyperparams={}, n_steps=20, num_repeats=1):
 	"""Trains a quantum circuit for n_steps steps with a gradient descent optimizer.
 

--- a/benchmarks/benchmark_functions/vqe.py
+++ b/benchmarks/benchmark_functions/vqe.py
@@ -50,5 +50,3 @@ def benchmark_vqe(hyperparams={}):
 
 	for _ in range(n_steps):
 		params, energy = opt.step_and_cost(cost_fn, params)
-
-	print(params, energy)

--- a/benchmarks/benchmark_functions/vqe.py
+++ b/benchmarks/benchmark_functions/vqe.py
@@ -48,5 +48,7 @@ def benchmark_vqe(hyperparams={}):
 
 	opt = qml.GradientDescentOptimizer(stepsize=0.4)
 
-	for n in range(n_steps):
+	for _ in range(n_steps):
 		params, energy = opt.step_and_cost(cost_fn, params)
+
+	print(params, energy)


### PR DESCRIPTION
This PR:
* labels all "short" benchmarks with `short` in class name.  Used to be "light"
* removes `qml.enable_tape`
* combines interface benchmarks into one class with interface as hyperparameter
* moves H molecule hamiltonian definition to `hamiltonians.py` file

I'm changing the label "light" to "short", as selecting benchmarks based on "light" selected out "lightning.qubit" device benchmarks.