### PR TITLE
Increased timeout for heavy benchmarks

### DIFF
--- a/benchmarks/asv/app_suite.py
+++ b/benchmarks/asv/app_suite.py
@@ -59,6 +59,8 @@ class VQE_heavy:
     param_names = ['optimize']
 
     timeout = 600 # 10 minutes
+    repeat = (1, 1, 600) # Only collect one sample
+    number = 1 # one iteration in each sample
 
     def setup(self, optimize):
 
@@ -126,6 +128,8 @@ class QAOA_heavy:
     n_layers = 5
     graph = nx.complete_graph(20)
     timeout = 600 # 10 minutes
+    repeat = (1, 1, 600) # Only collect one sample
+    number = 1 # one iteration in each sample
 
     def time_minvertex_heavy(self):
         """Time a QAOA algorithm for finding the minimum vertex cover of a large graph."""
@@ -174,6 +178,8 @@ class ML_heavy:
     n_samples = 100
 
     timeout = 600 # 10 minutes
+    repeat = (1, 1, 600) # Only collect one sample
+    number = 1 # one iteration in each sample
 
     def time_ml_heavy(self, interface):
         """Time 50 training steps of a hybrid quantum machine learning example."""

--- a/benchmarks/asv/app_suite.py
+++ b/benchmarks/asv/app_suite.py
@@ -58,6 +58,8 @@ class VQE_heavy:
     params = ([False, True])
     param_names = ['optimize']
 
+    timeout = 600 # 10 minutes
+
     def setup(self, optimize):
 
         electrons = 2
@@ -123,6 +125,7 @@ class QAOA_heavy:
 
     n_layers = 5
     graph = nx.complete_graph(20)
+    timeout = 600 # 10 minutes
 
     def time_minvertex_heavy(self):
         """Time a QAOA algorithm for finding the minimum vertex cover of a large graph."""
@@ -169,6 +172,8 @@ class ML_heavy:
     param_names = ['interface']
     n_features = 10
     n_samples = 100
+
+    timeout = 600 # 10 minutes
 
     def time_ml_heavy(self, interface):
         """Time 50 training steps of a hybrid quantum machine learning example."""


### PR DESCRIPTION
The three "heavy benchmarks", now all have increased timeouts of ten minutes (600 seconds).

As well, repeat and number are specified so the benchmarks are only executed once.  This means we don't get statistics on the execution time, but given the amount of time necessary to execute even once, collecting statistics will be too computationally expensive on a routine basis.