### PR TITLE
Variable Initialization for braket pipeline benchmarks

### DIFF
--- a/benchmarks/benchmark_functions/pl-braket-pipeline.py
+++ b/benchmarks/benchmark_functions/pl-braket-pipeline.py
@@ -69,7 +69,6 @@ def benchmark_casual(dev_name, s3=None):
         qml.templates.BasicEntanglerLayers(params_, wires=range(n_wires))
         return qml.expval(qml.PauliZ(0))
 
-
     rng = pnp.random.default_rng(seed=42)
     params = pnp.array(rng.standard_normal((n_layers, n_wires)), requires_grad=True)
 
@@ -127,8 +126,7 @@ def benchmark_power(dev_name, s3=None):
     n_layers = 1
     graph = nx.complete_graph(n_wires)
 
-
-    x = 0.5 * pnp.ones((n_layers, 2))
+    params = 0.5 * pnp.ones((n_layers, 2))
     interface = "autograd"
     diff_method = "best"
     n_wires = len(graph.nodes)

--- a/benchmarks/benchmark_functions/pl-braket-pipeline.py
+++ b/benchmarks/benchmark_functions/pl-braket-pipeline.py
@@ -12,7 +12,7 @@
 """
 Fixed benchmarks for pennylane-braket pipelines.
 """
-from numpy.random import random
+
 import pennylane as qml
 import networkx as nx
 from pennylane import numpy as pnp
@@ -69,8 +69,10 @@ def benchmark_casual(dev_name, s3=None):
         qml.templates.BasicEntanglerLayers(params_, wires=range(n_wires))
         return qml.expval(qml.PauliZ(0))
 
-    params = random((n_layers, n_wires))
-    params = pnp.array(params, requires_grad=True)
+
+    rng = pnp.random.default_rng(seed=42)
+    params = pnp.array(rng.standard_normal((n_layers, n_wires)), requires_grad=True)
+
     opt = qml.GradientDescentOptimizer(stepsize=0.1)
 
     print("starting optimization")
@@ -125,7 +127,8 @@ def benchmark_power(dev_name, s3=None):
     n_layers = 1
     graph = nx.complete_graph(n_wires)
 
-    params = [[0.5] * n_layers, [0.5] * n_layers]
+
+    x = 0.5 * pnp.ones((n_layers, 2))
     interface = "autograd"
     diff_method = "best"
     n_wires = len(graph.nodes)


### PR DESCRIPTION
This PR changes the parameter initialization in the `pl-braket-pipeline.py` benchmarks.  

For the casual one, the parameters are randomly generated in the [updated numpy style](https://numpy.org/doc/stable/reference/random/index.html?highlight=random#module-numpy.random) with a fixed seed for repeatable, consistent execution.

For the power one, the parameter is now a pennylane numpy array instead of a list of lists.  NumPy arrays are the preferred method for efficiency, and that should be reflected in our benchmarks.