### PR TITLE
Explicitly disable device caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 *.pyc
 PennyLane/
+pennylane/
 .asv
 
 profiles/

--- a/benchmarks/benchmark_functions/circuit.py
+++ b/benchmarks/benchmark_functions/circuit.py
@@ -44,16 +44,18 @@ def benchmark_circuit(hyperparams={}, num_repeats=1):
 
                     * 'template': Template to use. The template must take the trainable parameters as its only argument.
 
-                    * 'params': Numpy array of trainable parameters that is fed into the template.
+                    * 'param_shape': numpy array of trainable parameters that is fed into the template
 
                     * 'measurement': measurement function like `qml.expval(qml.PauliZ(0)))`
 
             num_repeats (int): How often the same circuit is evaluated in a for loop. Default is 1.
     """
 
-    device, diff_method, interface, params, template, measurement = _core_defaults(hyperparams)
+    device, diff_method, interface, param_shape, template, measurement = _core_defaults(hyperparams)
 
     for _ in range(num_repeats):
+
+        params = pnp.random.random(param_shape)
 
         @qml.qnode(device, interface=interface, diff_method=diff_method)
         def circuit(params_):

--- a/benchmarks/benchmark_functions/default_settings.py
+++ b/benchmarks/benchmark_functions/default_settings.py
@@ -24,7 +24,6 @@ from functools import partial
 from pennylane.templates import BasicEntanglerLayers
 from pennylane.templates.decorator import template as template_decorator
 from pennylane.templates.subroutines import UCCSD
-from pennylane import Identity, PauliX, PauliY, PauliZ
 
 from .hamiltonians import ham_h2
 
@@ -48,9 +47,13 @@ def _core_defaults(hyperparams):
     # if device name is given, create device
     if isinstance(device, str):
         if device == "cirq.pasqal":
-            device = qml.device(device, wires=n_wires, control_radius=1.5)
+            device = qml.device(device, wires=n_wires, control_radius=1.5, cache=0)
         else:
-            device = qml.device(device, wires=n_wires)
+            try:
+                device = qml.device(device, wires=n_wires, cache=0)
+            except TypeError:
+                # devices that do not inherit from DefaultQubit do not take caching argument
+                device = qml.device(device, wires=n_wires)
 
     # wrap default template so it only takes the parameters as argument
     if template is None:
@@ -99,11 +102,16 @@ def _vqe_defaults(hyperparams):
 
     options_dict = {"interface": interface, "diff_method": diff_method, "optimize": optimize}
 
+    # if device name is given, create device
     if isinstance(device, str):
         if device == "cirq.pasqal":
-            device = qml.device(device, wires=n_wires, control_radius=1.5)
+            device = qml.device(device, wires=n_wires, control_radius=1.5, cache=0)
         else:
-            device = qml.device(device, wires=n_wires)
+            try:
+                device = qml.device(device, wires=n_wires, cache=0)
+            except TypeError:
+                # devices that do not inherit from DefaultQubit do not take caching argument
+                device = qml.device(device, wires=n_wires)
 
     return ham, ansatz, params, n_steps, device, options_dict
 
@@ -126,7 +134,14 @@ def _qaoa_defaults(hyperparams):
 
     # if device name is given, create device
     if isinstance(device, str):
-        device = qml.device(device, wires=len(graph.nodes), analytic=False)
+        if device == "cirq.pasqal":
+            device = qml.device(device, wires=len(graph.nodes), shots=None, control_radius=1.5, cache=0)
+        else:
+            try:
+                device = qml.device(device, wires=len(graph.nodes), shots=None, cache=0)
+            except TypeError:
+                # devices that do not inherit from DefaultQubit do not take caching argument
+                device = qml.device(device, wires=len(graph.nodes), shots=None)
 
     options_dict = {"interface": interface, "diff_method": diff_method}
 
@@ -148,7 +163,14 @@ def _ml_defaults(hyperparams):
 
     # if device name is given, create device
     if isinstance(device, str):
-        device = qml.device(device, wires=n_features)
+        if device == "cirq.pasqal":
+            device = qml.device(device, wires=n_features, control_radius=1.5, cache=0)
+        else:
+            try:
+                device = qml.device(device, wires=n_features, cache=0)
+            except TypeError:
+                # devices that do not inherit from DefaultQubit do not take caching argument
+                device = qml.device(device, wires=n_features)
 
     # data
     x0 = np.random.normal(loc=-1, scale=1, size=(n_samples // 2, n_features))

--- a/benchmarks/benchmark_functions/default_settings.py
+++ b/benchmarks/benchmark_functions/default_settings.py
@@ -38,7 +38,7 @@ def _core_defaults(hyperparams):
     n_wires = hyperparams.pop("n_wires", 4)
     n_layers = hyperparams.pop("n_layers", 6)
     interface = hyperparams.pop("interface", "autograd")
-    params = hyperparams.pop("params", random(size=(n_layers, n_wires)))
+    param_shape = hyperparams.pop("param_shape", (n_layers, n_wires))
     measurement = hyperparams.pop("measurement", qml.expval(qml.PauliZ(0)))
     diff_method = hyperparams.pop("diff_method", "best")
     device = hyperparams.pop("device", "default.qubit")
@@ -64,7 +64,7 @@ def _core_defaults(hyperparams):
 
         template = Template
 
-    return device, diff_method, interface, params, template, measurement
+    return device, diff_method, interface, param_shape, template, measurement
 
 
 def _vqe_defaults(hyperparams):

--- a/benchmarks/benchmark_functions/gradient.py
+++ b/benchmarks/benchmark_functions/gradient.py
@@ -41,14 +41,14 @@ def benchmark_gradient(hyperparams={}, num_repeats=1):
 
                     * 'template': Template to use. The template must take the trainable parameters as its only argument.
 
-                    * 'params': Numpy array of trainable parameters that is fed into the template.
+                    * 'param_shape': numpy array of trainable parameters that is fed into the template
 
                     * 'measurement': measurement function like `qml.expval(qml.PauliZ(0)))`
 
             num_repeats (int): How often the same circuit is evaluated in a for loop. Default is 1.
     """
 
-    device, diff_method, interface, params, template, measurement = _core_defaults(hyperparams)
+    device, diff_method, interface, param_shape, template, measurement = _core_defaults(hyperparams)
 
     @qml.qnode(device, interface=interface, diff_method=diff_method)
     def circuit(params_):
@@ -57,6 +57,10 @@ def benchmark_gradient(hyperparams={}, num_repeats=1):
         return measurement
 
     for _ in range(num_repeats):
+
+        # re-initialise the parameters each time,
+        # so caching cannot skew the results
+        params = pnp.random.random(param_shape)
 
         if interface == "autograd":
             params = pnp.array(params, requires_grad=True)

--- a/benchmarks/benchmark_functions/optimization.py
+++ b/benchmarks/benchmark_functions/optimization.py
@@ -41,7 +41,7 @@ def benchmark_optimization(hyperparams={}, n_steps=20, num_repeats=1):
 
             * 'template': Template to use. The template must take the trainable parameters as its only argument.
 
-            * 'params': Numpy array of trainable parameters that is fed into the template.
+            * 'param_shape': numpy array of trainable parameters that is fed into the template
 
             * 'measurement': measurement function like `qml.expval(qml.PauliZ(0)))`
 
@@ -49,7 +49,7 @@ def benchmark_optimization(hyperparams={}, n_steps=20, num_repeats=1):
     num_repeats (int): How often the same circuit is evaluated in a for loop. Default is 1.
     """
 
-    device, diff_method, interface, params, template, measurement = _core_defaults(hyperparams)
+    device, diff_method, interface, param_shape, template, measurement = _core_defaults(hyperparams)
 
     @qml.qnode(device, interface=interface, diff_method=diff_method)
     def circuit(params_):
@@ -58,6 +58,8 @@ def benchmark_optimization(hyperparams={}, n_steps=20, num_repeats=1):
         return measurement
 
     for _ in range(num_repeats):
+
+        params = pnp.random.random(param_shape)
 
         if interface == "autograd":
             params = pnp.array(params, requires_grad=True)


### PR DESCRIPTION
To be safe we do not record results from cached runs, this PR sets the number of caches saved by the device explicitly to 0.

This does not seem to make a difference at the moment, since `cache=0` is the default.

In addition, this PR adds the pasqal device compatibility fix to all default settings.