### PR TITLE
Jax gradient benchmark

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -51,6 +51,8 @@
     "matrix": {
         "tensorflow": [],
         "torch": [],
+        "jax": [],
+        "jaxlib": [],
         "networkx": [],
         "Qulacs": [],
         "qsimcirq": [],

--- a/benchmarks/asv/core_suite.py
+++ b/benchmarks/asv/core_suite.py
@@ -34,7 +34,7 @@ class CircuitEvaluation_light:
 class GradientComputation_light:
     """Time the computation of a gradient using different widths and depths."""
 
-    params = ([2, 5], [3, 6], ["autograd", "tf", "torch"])
+    params = ([2, 5], [3, 6], ["autograd", "tf", "torch", "jax"])
     param_names = ["n_wires", "n_layers", "interface"]
 
     def time_gradient(self, n_wires, n_layers, interface):

--- a/benchmarks/benchmark_functions/gradient.py
+++ b/benchmarks/benchmark_functions/gradient.py
@@ -18,6 +18,11 @@ import pennylane as qml
 from pennylane import numpy as pnp
 from .default_settings import _core_defaults
 
+try:
+    import jax
+    from jax import numpy as jnp
+except ImportError:
+    pass
 
 def benchmark_gradient(hyperparams={}, num_repeats=1):
     """Computes the gradient of a quantum circuit.
@@ -78,4 +83,10 @@ def benchmark_gradient(hyperparams={}, num_repeats=1):
             result = circuit(params)
             result.backward()
 
-        # TODO: jax
+        elif interface == "jax":
+
+            params = jnp.array(params)
+
+            jac = jax.jacobian(circuit)
+            jac(params)
+


### PR DESCRIPTION
This PR adds the jax interface to the gradient benchmarking.  This means `jax` and `jaxlib` are now dependencies for the full environment.  

The benchmarks ran on my machine.

Given this data, we should really figure out why the jax interface is so incredibly slow.

```
 ========= ========== ============ ============ ============ ============
--                                        interface
-------------------- ---------------------------------------------------
 n_wires   n_layers    autograd        tf         torch         jax
========= ========== ============ ============ ============ ============
    2         3       7.19±0.3ms   23.8±0.2ms   9.98±0.2ms    217±4ms
    2         6       10.8±0.9ms   42.7±0.5ms   24.8±0.4ms    355±10ms
    5         3       15.4±0.4ms    62.7±3ms     47.0±1ms    1.04±0.01s
    5         6        25.8±1ms     120±1ms      164±4ms     1.46±0.01s
========= ========== ============ ============ ============ ============
```