### PR TITLE
Update pl-braket-pipeline.py

### DIFF
--- a/benchmarks/benchmark_functions/pl-braket-pipeline.py
+++ b/benchmarks/benchmark_functions/pl-braket-pipeline.py
@@ -127,7 +127,7 @@ def benchmark_power(dev_name, s3=None):
     n_layers = 1
     graph = nx.complete_graph(n_wires)
 
-    params = 0.5 * pnp.ones((n_layers, 2))
+    params = 0.5 * pnp.ones((2, n_layers))
     interface = "autograd"
     diff_method = "best"
     n_wires = len(graph.nodes)


### PR DESCRIPTION
Updates the shape for the input parameters of the QAOA benchmark. The current version yields:
```python
~/xanadu/pennylane/pennylane/numpy/tensor.py in __getitem__(self, *args, **kwargs)
    182 
    183     def __getitem__(self, *args, **kwargs):
--> 184         item = super().__getitem__(*args, **kwargs)
    185 
    186         if not isinstance(item, tensor):

IndexError: index 1 is out of bounds for axis 0 with size 1
```